### PR TITLE
Make recorder tests optional on missing dataset

### DIFF
--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -1,0 +1,11 @@
+# Test Data Overview
+
+This directory contains Home Assistant recorder databases that can be used to manually test the editor CLI. No datasets are committed to the repository so you can bring your own sample without bloating the history with large binaries.
+
+## Adding `home-assistant_v2.db`
+
+1. Download the recorder database from [`pia2209/config`](https://github.com/pia2209/config/raw/refs/heads/main/home-assistant_v2.db).
+2. Place the file in this directory so it sits alongside this README (`tests/data/home-assistant_v2.db`).
+3. Re-run the test suite. The pytest module automatically copies the database into a temporary directory for each test to keep the original pristine.
+
+If you prefer to keep the dataset elsewhere, set the `RECORDER_FIXER_TEST_DB` environment variable to an absolute path before invoking pytest.

--- a/tests/test_fixer.py
+++ b/tests/test_fixer.py
@@ -1,0 +1,82 @@
+import os
+import shutil
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from fixer import RecorderFixer
+
+_DEFAULT_DB = Path(__file__).resolve().parent / "data" / "home-assistant_v2.db"
+TEST_DB = Path(os.environ.get("RECORDER_FIXER_TEST_DB", _DEFAULT_DB))
+
+if not TEST_DB.exists():
+    pytest.skip(
+        "Recorder test database not found. Download the dataset into tests/data/ "
+        "or set RECORDER_FIXER_TEST_DB to an existing recorder DB file.",
+        allow_module_level=True,
+    )
+
+
+@pytest.fixture
+def fresh_db_path(tmp_path):
+    """Copy the recorder DB so every test starts from a clean slate."""
+    db_copy = tmp_path / "home-assistant_v2.db"
+    shutil.copy(TEST_DB, db_copy)
+    return db_copy
+
+
+@pytest.fixture
+def fixer(fresh_db_path):
+    instance = RecorderFixer(str(fresh_db_path))
+    try:
+        yield instance
+    finally:
+        instance.close()
+
+
+def test_get_metadata_id_returns_expected_value(fixer):
+    assert fixer.get_metadata_id("zone.home") == 1
+
+
+def test_get_unique_values_lists_known_binary_sensor_states(fixer):
+    assert fixer.get_unique_values("binary_sensor.fritzbox_pia_verbindung") == [
+        "on",
+        "unavailable",
+    ]
+
+
+def test_delete_state_everywhere_removes_matching_states(fixer, fresh_db_path):
+    entity_id = "binary_sensor.fritzbox_pia_verbindung"
+    state_value = "on"
+
+    metadata_id = fixer.get_metadata_id(entity_id)
+    assert metadata_id is not None
+
+    with sqlite3.connect(fresh_db_path) as conn:
+        before = conn.execute(
+            "SELECT COUNT(*) FROM states WHERE metadata_id = ? AND state = ?",
+            (metadata_id, state_value),
+        ).fetchone()[0]
+        assert before > 0
+
+    deleted = fixer.delete_state_everywhere(entity_id, state_value)
+    assert deleted == before
+
+    with sqlite3.connect(fresh_db_path) as conn:
+        after = conn.execute(
+            "SELECT COUNT(*) FROM states WHERE metadata_id = ? AND state = ?",
+            (metadata_id, state_value),
+        ).fetchone()[0]
+        assert after == 0
+
+        remaining = conn.execute(
+            "SELECT COUNT(*) FROM states WHERE metadata_id = ? AND state = ?",
+            (metadata_id, "unavailable"),
+        ).fetchone()[0]
+        assert remaining > 0


### PR DESCRIPTION
## Summary
- document how to place the optional recorder dataset without committing the binary
- allow the pytest suite to reference an external recorder DB path and skip when it is absent

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d80457434c8332991280d10a225ed7