### PR TITLE
Increase around window and filter placeholder states

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import textwrap
 from collections.abc import Callable, Iterable
+from datetime import datetime, timezone
 from pathlib import Path
 
 from prompt_toolkit import PromptSession
@@ -28,6 +29,15 @@ WARNING_TEXT = textwrap.dedent(
     """
 )
 
+PLACEHOLDER_STATES = {
+    "unknown",
+    "unavailable",
+    "undefined",
+    "none",
+    "null",
+    "nan",
+}
+
 HELP_TEXT = textwrap.dedent(
     """
     Available commands:
@@ -36,6 +46,10 @@ HELP_TEXT = textwrap.dedent(
       sensor find <entity_id>            - Show metadata_id + quick state preview
       sensor values <entity_id>          - Show all unique state values of a sensor
       sensor raw <entity_id>             - Show last 200 raw records for a sensor
+      sensor find_value <entity_id> <value> [tolerance]
+                                        - Show records close to a value
+      sensor around <entity_id> <value> [tolerance] [window]
+                                        - Show nearby records for candidate values
       sensor delete <entity_id> <value>  - Delete entries with specific state value
 
       password                           - Change password for user 'debug'
@@ -54,6 +68,8 @@ def build_completer(entity_ids: Iterable[str]) -> NestedCompleter:
         "delete": entity_completer,
         "values": entity_completer,
         "raw": entity_completer,
+        "around": entity_completer,
+        "find_value": entity_completer,
         "find": entity_completer,
         "list_all": None,
     }
@@ -162,6 +178,17 @@ class RecorderCli:
         os.system("cls" if os.name == "nt" else "clear")
         self._print_help()
 
+    @staticmethod
+    def _is_placeholder_state(state: object) -> bool:
+        if state is None:
+            return True
+
+        text = str(state).strip()
+        if not text:
+            return True
+
+        return text.lower() in PLACEHOLDER_STATES
+
     # ------------------------------------------------------------------
     # sensor commands
     def _handle_sensor_command(self, args: list[str]) -> None:
@@ -175,6 +202,8 @@ class RecorderCli:
             "find": lambda: self._sensor_find(args),
             "values": lambda: self._sensor_values(args),
             "raw": lambda: self._sensor_raw(args),
+            "around": lambda: self._sensor_around(args),
+            "find_value": lambda: self._sensor_find_value(args),
             "delete": lambda: self._sensor_delete(args),
         }
 
@@ -207,7 +236,11 @@ class RecorderCli:
         print(f"metadata_id for '{entity_id}' is {metadata_id}")
         states = self._fixer.list_states_by_id(metadata_id)
         for state in states[:5]:
-            print(f"  {state['last_updated']} → {state['state']} (id: {state['state_id']})")
+            print(
+                "  "
+                f"{self._format_timestamp(state)} → {state['state']} "
+                f"(id: {state['state_id']})"
+            )
 
     def _sensor_values(self, args: list[str]) -> None:
         entity_id = self._require_entity_id(args, usage="sensor values <entity_id>")
@@ -233,7 +266,221 @@ class RecorderCli:
             return
 
         for row in rows:
-            print(f"  {row['last_updated']} → {row['state']} (id: {row['state_id']})")
+            print(
+                "  "
+                f"{self._format_timestamp(row)} → {row['state']} "
+                f"(id: {row['state_id']})"
+            )
+
+    def _sensor_find_value(self, args: list[str]) -> None:
+        if len(args) < 3:
+            print("Usage: sensor find_value <entity_id> <value> [tolerance]")
+            return
+
+        entity_id = args[1]
+        value = args[2]
+
+        tolerance: float | None = None
+        if len(args) >= 4:
+            try:
+                tolerance = float(args[3])
+            except ValueError:
+                print("Tolerance must be a numeric value.")
+                return
+
+        matches = self._fixer.find_states_for_value(
+            entity_id,
+            value,
+            tolerance=tolerance if tolerance is not None else 0.01,
+        )
+
+        if not matches:
+            print(
+                f"No states close to '{value}' found for sensor '{entity_id}'."
+            )
+            return
+
+        numeric_target: float | None = None
+        try:
+            numeric_target = float(value)
+        except (TypeError, ValueError):
+            numeric_target = None
+
+        effective_tolerance = (
+            tolerance if tolerance is not None else (0.01 if numeric_target is not None else 0.0)
+        )
+
+        if numeric_target is not None:
+            print(f"Matches for '{value}' (±{effective_tolerance:.6g})")
+        else:
+            print(f"Matches for '{value}'")
+
+        displayed = 0
+        skipped = 0
+
+        for row in matches:
+            if self._is_placeholder_state(row["state"]):
+                skipped += 1
+                continue
+
+            timestamp = self._format_timestamp(row)
+            base = f"  {timestamp} → {row['state']} (id: {row['state_id']})"
+
+            if numeric_target is not None:
+                try:
+                    diff = abs(float(row["state"]) - numeric_target)
+                except (TypeError, ValueError):
+                    diff = None
+                if diff is not None:
+                    base += f" [Δ={diff:.6g}]"
+
+            print(base)
+            displayed += 1
+
+        if displayed == 0:
+            if skipped:
+                print("No non-placeholder states matched the criteria.")
+            return
+
+        if skipped:
+            print(f"  (Skipped {skipped} placeholder state(s))")
+
+    def _sensor_around(self, args: list[str]) -> None:
+        if len(args) < 3:
+            print(
+                "Usage: sensor around <entity_id> <value> [tolerance] [window]"
+            )
+            return
+
+        entity_id = args[1]
+        value = args[2]
+
+        tolerance: float | None = None
+        window = 5
+
+        if len(args) >= 4:
+            try:
+                tolerance = float(args[3])
+            except ValueError:
+                print("Tolerance must be a numeric value.")
+                return
+
+        if len(args) >= 5:
+            try:
+                window = int(args[4])
+            except ValueError:
+                print("Window must be an integer value.")
+                return
+
+            if window < 0:
+                print("Window must be zero or greater.")
+                return
+
+        matches = self._fixer.find_states_for_value(
+            entity_id,
+            value,
+            tolerance=tolerance if tolerance is not None else 0.01,
+        )
+
+        if not matches:
+            print(
+                f"No states close to '{value}' found for sensor '{entity_id}'."
+            )
+            return
+
+        numeric_target: float | None = None
+        try:
+            numeric_target = float(value)
+        except (TypeError, ValueError):
+            numeric_target = None
+
+        effective_tolerance = (
+            tolerance if tolerance is not None else (0.01 if numeric_target is not None else 0.0)
+        )
+
+        header = (
+            f"Exploring matches for '{value}' (±{effective_tolerance:.6g})"
+            if numeric_target is not None
+            else f"Exploring matches for '{value}'"
+        )
+        print(header)
+        print(f"Window size: {window} before/after")
+
+        display_index = 0
+        skipped_candidates = 0
+        skipped_neighbors = 0
+
+        for row in matches:
+            if self._is_placeholder_state(row["state"]):
+                skipped_candidates += 1
+                continue
+
+            before_rows, anchor, after_rows = self._fixer.get_state_context(
+                entity_id,
+                row["state_id"],
+                before=window,
+                after=window,
+            )
+
+            if anchor is None:
+                continue
+
+            if self._is_placeholder_state(anchor["state"]):
+                skipped_candidates += 1
+                continue
+
+            filtered_before = [
+                record for record in before_rows if not self._is_placeholder_state(record["state"])
+            ]
+            filtered_after = [
+                record for record in after_rows if not self._is_placeholder_state(record["state"])
+            ]
+            skipped_neighbors += (len(before_rows) - len(filtered_before)) + (
+                len(after_rows) - len(filtered_after)
+            )
+
+            print(
+                f"[{display_index + 1}] Candidate at {self._format_timestamp(anchor)}"
+                f" → {anchor['state']} (id: {anchor['state_id']})"
+            )
+            display_index += 1
+
+            def _format_row(prefix: str, record) -> str:
+                line = (
+                    f"    {prefix} {self._format_timestamp(record)} → {record['state']}"
+                    f" (id: {record['state_id']})"
+                )
+                if numeric_target is not None:
+                    try:
+                        diff = abs(float(record["state"]) - numeric_target)
+                    except (TypeError, ValueError):
+                        diff = None
+                    if diff is not None:
+                        line += f" [Δ={diff:.6g}]"
+                return line
+
+            for before_row in filtered_before:
+                print(_format_row("↑", before_row))
+
+            print(_format_row("•", anchor))
+
+            for after_row in filtered_after:
+                print(_format_row("↓", after_row))
+
+        if display_index == 0:
+            if skipped_candidates:
+                print("No non-placeholder states available within the selected window.")
+            return
+
+        notes: list[str] = []
+        if skipped_candidates:
+            notes.append(f"{skipped_candidates} candidate(s)")
+        if skipped_neighbors:
+            notes.append(f"{skipped_neighbors} neighbor state(s)")
+
+        if notes:
+            joined = " and ".join(notes)
+            print(f"  (Skipped {joined} lacking meaningful data)")
 
     def _sensor_delete(self, args: list[str]) -> None:
         if len(args) != 3:
@@ -270,6 +517,31 @@ class RecorderCli:
             print(f"Usage: {usage}")
             return None
         return args[1]
+
+    @staticmethod
+    def _format_timestamp(row) -> str:
+        value = None
+        try:
+            value = row["last_updated"]
+        except (KeyError, TypeError):
+            pass
+
+        if value:
+            return str(value)
+
+        timestamp = None
+        try:
+            timestamp = row["last_updated_ts"]
+        except (KeyError, TypeError):
+            pass
+
+        if timestamp is None:
+            return "unknown"
+
+        try:
+            return datetime.fromtimestamp(float(timestamp), tz=timezone.utc).isoformat()
+        except (TypeError, ValueError, OSError):
+            return str(timestamp)
 
 
 def prompt_for_database_path(default_path: Path = DEFAULT_DB_PATH) -> Path | None:

--- a/fixer.py
+++ b/fixer.py
@@ -177,10 +177,10 @@ class RecorderFixer:
             return []
         cur = self.conn.execute(
             """
-            SELECT state_id, state, last_updated
+            SELECT state_id, state, last_updated, last_updated_ts
             FROM states
             WHERE metadata_id = ?
-            ORDER BY last_updated DESC
+            ORDER BY COALESCE(last_updated_ts, 0) DESC
             LIMIT ?
             """,
             (metadata_id, limit),
@@ -190,15 +190,144 @@ class RecorderFixer:
     def list_states_by_id(self, metadata_id: int, limit: int = 200):
         cur = self.conn.execute(
             """
-            SELECT state_id, state, last_updated
+            SELECT state_id, state, last_updated, last_updated_ts
             FROM states
             WHERE metadata_id = ?
-            ORDER BY last_updated DESC
+            ORDER BY COALESCE(last_updated_ts, 0) DESC
             LIMIT ?
             """,
             (metadata_id, limit),
         )
         return cur.fetchall()
+
+    def find_states_for_value(
+        self,
+        entity_id: str,
+        state_value: str,
+        *,
+        tolerance: float = 0.01,
+        limit: int = 200,
+    ) -> list[sqlite3.Row]:
+        """Return rows whose state matches ``state_value`` (with tolerance)."""
+
+        metadata_id = self.get_metadata_id(entity_id)
+        if metadata_id is None:
+            return []
+
+        rows: list[sqlite3.Row] = []
+        seen_state_ids: set[int] = set()
+
+        cursor = self.conn.execute(
+            """
+            SELECT state_id, state, last_updated, last_updated_ts
+            FROM states
+            WHERE metadata_id = ? AND state = ?
+            ORDER BY COALESCE(last_updated_ts, 0) DESC
+            LIMIT ?
+            """,
+            (metadata_id, state_value, limit),
+        )
+        exact_matches = cursor.fetchall()
+        for row in exact_matches:
+            rows.append(row)
+            seen_state_ids.add(row["state_id"])
+
+        numeric_value = self._coerce_state_to_float(state_value)
+        tolerance = abs(tolerance)
+
+        if numeric_value is None or tolerance == 0:
+            return rows
+
+        candidate_cursor = self.conn.execute(
+            """
+            SELECT state_id, state, last_updated, last_updated_ts
+            FROM states
+            WHERE metadata_id = ?
+            ORDER BY ABS(CAST(state AS REAL) - ?), COALESCE(last_updated_ts, 0) DESC
+            LIMIT ?
+            """,
+            (metadata_id, numeric_value, limit * 3),
+        )
+
+        for row in candidate_cursor.fetchall():
+            state_id = row["state_id"]
+            if state_id in seen_state_ids:
+                continue
+
+            row_value = self._coerce_state_to_float(row["state"])
+            if row_value is None:
+                continue
+
+            if math.isfinite(row_value) and abs(row_value - numeric_value) <= tolerance:
+                rows.append(row)
+                seen_state_ids.add(state_id)
+
+            if len(rows) >= limit:
+                break
+
+        rows.sort(
+            key=lambda r: (
+                r["last_updated_ts"] if r["last_updated_ts"] is not None else 0,
+                r["last_updated"] if r["last_updated"] is not None else "",
+            ),
+            reverse=True,
+        )
+
+        return rows
+
+    def get_state_context(
+        self,
+        entity_id: str,
+        state_id: int,
+        *,
+        before: int = 2,
+        after: int = 2,
+    ) -> tuple[list[sqlite3.Row], sqlite3.Row | None, list[sqlite3.Row]]:
+        """Return rows surrounding the provided ``state_id`` for an entity."""
+
+        before = max(0, before)
+        after = max(0, after)
+
+        metadata_id = self.get_metadata_id(entity_id)
+        if metadata_id is None:
+            return ([], None, [])
+
+        anchor = self.conn.execute(
+            """
+            SELECT state_id, state, last_updated, last_updated_ts
+            FROM states
+            WHERE metadata_id = ? AND state_id = ?
+            """,
+            (metadata_id, state_id),
+        ).fetchone()
+
+        if anchor is None:
+            return ([], None, [])
+
+        before_rows = self.conn.execute(
+            """
+            SELECT state_id, state, last_updated, last_updated_ts
+            FROM states
+            WHERE metadata_id = ? AND state_id < ?
+            ORDER BY state_id DESC
+            LIMIT ?
+            """,
+            (metadata_id, state_id, before),
+        ).fetchall()
+        before_rows.reverse()
+
+        after_rows = self.conn.execute(
+            """
+            SELECT state_id, state, last_updated, last_updated_ts
+            FROM states
+            WHERE metadata_id = ? AND state_id > ?
+            ORDER BY state_id ASC
+            LIMIT ?
+            """,
+            (metadata_id, state_id, after),
+        ).fetchall()
+
+        return (before_rows, anchor, after_rows)
 
     def close(self) -> None:
         self.conn.close()

--- a/tests/test_fixer.py
+++ b/tests/test_fixer.py
@@ -74,6 +74,57 @@ def test_get_unique_values_lists_known_states(fixer, entity_id, expected_subset)
     assert expected_subset.issubset(set(values))
 
 
+def test_find_states_for_value_returns_exact_matches(fixer):
+    rows = fixer.find_states_for_value(
+        "binary_sensor.fritzbox_pia_verbindung",
+        "unavailable",
+    )
+
+    assert rows, "expected to find at least one unavailable state"
+    assert all(row["state"] == "unavailable" for row in rows)
+    assert "last_updated_ts" in rows[0].keys()
+
+
+def test_find_states_for_value_accepts_float_tolerance(fixer):
+    rows = fixer.find_states_for_value(
+        "sensor.fritzbox_pia_gb_empfangen",
+        "30.3004",
+        tolerance=0.01,
+    )
+
+    assert rows, "expected to find states close to 30.3004"
+    assert any(row["state"] == "30.3" for row in rows)
+
+
+def test_get_state_context_returns_neighbors(fixer):
+    rows = fixer.find_states_for_value(
+        "sensor.fritzbox_pia_gb_empfangen",
+        "30.3004",
+        tolerance=0.02,
+    )
+
+    assert rows, "expected candidate states for context inspection"
+
+    state_id = rows[0]["state_id"]
+    before_rows, anchor, after_rows = fixer.get_state_context(
+        "sensor.fritzbox_pia_gb_empfangen",
+        state_id,
+        before=2,
+        after=2,
+    )
+
+    assert anchor is not None
+    assert anchor["state_id"] == state_id
+
+    previous_ids = [row["state_id"] for row in before_rows]
+    assert previous_ids == sorted(previous_ids)
+    assert all(row["state_id"] < state_id for row in before_rows)
+
+    following_ids = [row["state_id"] for row in after_rows]
+    assert following_ids == sorted(following_ids)
+    assert all(row["state_id"] > state_id for row in after_rows)
+
+
 def test_delete_state_everywhere_removes_matching_states(fixer, fresh_db_path):
     entity_id = "binary_sensor.fritzbox_pia_verbindung"
     state_value = "on"


### PR DESCRIPTION
## Summary
- increase the default window for `sensor around` to provide broader context around candidate states
- skip placeholder state values (unknown, unavailable, undefined, etc.) when rendering `sensor around` and `sensor find_value` output, reporting the number of filtered records
- add helper logic so these commands keep sequential numbering and show when placeholder neighbors were removed

## Testing
- pytest
- ruff check
- python - <<'PY'
import sqlite3
from pathlib import Path

db_path = Path('test_cli.db')
if db_path.exists():
    db_path.unlink()

conn = sqlite3.connect(db_path)
cur = conn.cursor()
cur.execute('CREATE TABLE states_meta (metadata_id INTEGER PRIMARY KEY, entity_id TEXT)')
cur.execute(
    'CREATE TABLE states ('
    'state_id INTEGER PRIMARY KEY AUTOINCREMENT,'
    'metadata_id INTEGER,'
    'state TEXT,'
    'last_updated TEXT,'
    'last_updated_ts REAL)'
)

cur.execute('INSERT INTO states_meta (metadata_id, entity_id) VALUES (?, ?)', (1, 'sensor.test_numeric'))
cur.execute('INSERT INTO states_meta (metadata_id, entity_id) VALUES (?, ?)', (2, 'binary_sensor.placeholder'))

rows = [
    (1, '10.0', '2024-01-01 00:00:00', 1704067200),
    (1, '10.5', '2024-01-01 01:00:00', 1704070800),
    (1, 'unknown', '2024-01-01 02:00:00', 1704074400),
    (1, '11.0', '2024-01-01 03:00:00', 1704078000),
    (1, 'undefined', '2024-01-01 04:00:00', 1704081600),
    (1, '11.5', '2024-01-01 05:00:00', 1704085200),
]

cur.executemany(
    'INSERT INTO states (metadata_id, state, last_updated, last_updated_ts) VALUES (?, ?, ?, ?)',
    rows,
)

rows_placeholder = [
    (2, 'unavailable', '2024-01-02 00:00:00', 1704153600),
    (2, 'on', '2024-01-02 01:00:00', 1704157200),
    (2, 'off', '2024-01-02 02:00:00', 1704160800),
]
cur.executemany(
    'INSERT INTO states (metadata_id, state, last_updated, last_updated_ts) VALUES (?, ?, ?, ?)',
    rows_placeholder,
)

conn.commit()
conn.close()
PY
- python - <<'PY'
import sys, types

prompt_toolkit = types.ModuleType('prompt_toolkit')

class DummySession:
    def __init__(self, *args, **kwargs):
        pass

    def prompt(self, *args, **kwargs):
        raise EOFError

prompt_toolkit.PromptSession = DummySession

completion = types.ModuleType('prompt_toolkit.completion')

class DummyNestedCompleter:
    @staticmethod
    def from_nested_dict(mapping):
        return None

completion.NestedCompleter = DummyNestedCompleter

sys.modules['prompt_toolkit'] = prompt_toolkit
sys.modules['prompt_toolkit.completion'] = completion

from cli import RecorderCli
from fixer import RecorderFixer

fixer = RecorderFixer('test_cli.db')
cli = RecorderCli(fixer)
print('--- around (default window) ---')
cli._sensor_around(['around', 'sensor.test_numeric', '11', '0.6'])
print('\n--- around (window 1) ---')
cli._sensor_around(['around', 'binary_sensor.placeholder', 'unavailable', '0.0', '1'])
print('\n--- find_value ---')
cli._sensor_find_value(['find_value', 'sensor.test_numeric', '11', '0.6'])
print('\n--- find_value placeholders ---')
cli._sensor_find_value(['find_value', 'binary_sensor.placeholder', 'unavailable'])
fixer.close()
PY

------
https://chatgpt.com/codex/tasks/task_b_68d859a2be5883328c3377a500598fdb