### PR TITLE
Add confirmation flow to sensor delete_id command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+- Always increment the `version` field in `config.yaml` as part of every pull request.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Enter path to HA database or press ENTER key for confirm default `/config/home-a
 | `sensor values <entity_id>`              | List all unique values stored for the sensor. |
 | `sensor raw <entity_id>`                 | Show 200 recent raw `states` records. |
 | `sensor delete <entity_id> <value>`      | Completely delete value from `states`, `statistics`, and `statistics_short_term`. |
+| `sensor delete_id <entity_id> <state_id>`| Preview nearby rows and confirm before deleting a single `states` entry by `state_id`. |
 
 ---
 

--- a/cli.py
+++ b/cli.py
@@ -52,6 +52,7 @@ HELP_TEXT = textwrap.dedent(
       sensor around <entity_id> <value> [tolerance] [window]
                                         - Show nearby records for candidate values
       sensor delete <entity_id> <value>  - Delete entries with specific state value
+      sensor delete_id <entity_id> <id>  - Delete single state row by ``state_id``
 
       password                           - Change password for user 'debug'
       clear                              - Clear the screen
@@ -67,6 +68,7 @@ def build_completer(entity_ids: Iterable[str]) -> NestedCompleter:
     entity_completer = {entity_id: None for entity_id in entity_ids}
     sensor_completer = {
         "delete": entity_completer,
+        "delete_id": entity_completer,
         "values": entity_completer,
         "raw": entity_completer,
         "inspect": entity_completer,
@@ -208,6 +210,7 @@ class RecorderCli:
             "around": lambda: self._sensor_around(args),
             "find_value": lambda: self._sensor_find_value(args),
             "delete": lambda: self._sensor_delete(args),
+            "delete_id": lambda: self._sensor_delete_by_id(args),
         }
 
         handler = dispatch.get(subcommand)
@@ -584,6 +587,72 @@ class RecorderCli:
             )
 
         self._refresh_entity_ids()
+
+    def _sensor_delete_by_id(self, args: list[str]) -> None:
+        if len(args) != 3:
+            print("Usage: sensor delete_id <entity_id> <state_id>")
+            return
+
+        entity_id = args[1]
+
+        try:
+            state_id = int(args[2])
+        except ValueError:
+            print("state_id must be an integer value.")
+            return
+
+        if self._fixer.get_metadata_id(entity_id) is None:
+            print(f"Sensor '{entity_id}' not found.")
+            return
+
+        before_rows, anchor, after_rows = self._fixer.get_state_context(
+            entity_id, state_id, before=3, after=3
+        )
+
+        if anchor is None:
+            print(
+                f"No record matched entity '{entity_id}' with state_id {state_id}."
+            )
+            return
+
+        print(f"Context around state_id {state_id} for '{entity_id}':")
+
+        def _render_row(prefix: str, row) -> None:
+            timestamp = self._format_timestamp(row)
+            print(
+                f"  {prefix} {timestamp} → {row['state']}"
+                f" (id: {row['state_id']})"
+            )
+
+        for row in before_rows:
+            _render_row("↑", row)
+
+        _render_row("•", anchor)
+
+        for row in after_rows:
+            _render_row("↓", row)
+
+        try:
+            confirmation = self._session.prompt(
+                "Type 'delete' to confirm removal (press Enter to cancel): ",
+                completer=None,
+            )
+        except (KeyboardInterrupt, EOFError):
+            print("\nDeletion cancelled.")
+            return
+
+        if confirmation.strip().lower() != "delete":
+            print("Deletion cancelled.")
+            return
+
+        deleted = self._fixer.delete_state_by_id(entity_id, state_id)
+        if not deleted:
+            print(
+                "The target row was not deleted (it may have already been removed)."
+            )
+            return
+
+        print("Deleted 1 row from states.")
 
     # ------------------------------------------------------------------
     # helpers

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "Homeassistant Recorder Database Editor"
 description: "Tool for edit and fix entities/sensors values in Homeassistant Recorder Database."
-version: "1.2"
+version: "1.3"
 slug: "ha_recorder_db_editor"
 url: "https://github.com/Duelion/ha-recorder-db-editor"
 init: false

--- a/fixer.py
+++ b/fixer.py
@@ -167,6 +167,25 @@ class RecorderFixer:
             self.conn.rollback()
             raise
 
+    def delete_state_by_id(self, entity_id: str, state_id: int) -> bool:
+        """Delete a single ``states`` row identified by ``state_id``."""
+
+        metadata_id = self.get_metadata_id(entity_id)
+        if metadata_id is None:
+            return False
+
+        try:
+            deleted_rows = self._execute_delete(
+                "DELETE FROM states WHERE metadata_id = ? AND state_id = ?",
+                (metadata_id, state_id),
+            )
+            self.conn.commit()
+        except sqlite3.DatabaseError:
+            self.conn.rollback()
+            raise
+
+        return deleted_rows > 0
+
     def list_all_sensors(self):
         cur = self.conn.execute(
             "SELECT entity_id, metadata_id FROM states_meta ORDER BY entity_id"

--- a/tests/test_fixer.py
+++ b/tests/test_fixer.py
@@ -165,7 +165,7 @@ def test_delete_state_everywhere_removes_matching_states(fixer, fresh_db_path):
             "SELECT COUNT(*) FROM states WHERE metadata_id = ? AND state = ?",
             (metadata_id, "unavailable"),
         ).fetchone()[0]
-        assert remaining > 0
+    assert remaining > 0
 
 
 def _count_statistics(conn, table, meta_id, numeric_value):
@@ -320,3 +320,47 @@ def test_delete_state_everywhere_skips_statistics_for_non_numeric_state(
     assert after_states == 0
     assert after_stats == before_stats
     assert after_short == before_short
+
+
+def test_delete_state_by_id_removes_single_row(fixer, fresh_db_path):
+    entity_id = "sensor.fritzbox_pia_gb_empfangen"
+    rows = fixer.get_raw_states(entity_id, limit=10)
+
+    assert rows, "expected raw states for the sensor"
+
+    target = rows[0]
+    target_state_id = target["state_id"]
+    target_state_value = target["state"]
+
+    metadata_id = fixer.get_metadata_id(entity_id)
+    assert metadata_id is not None
+
+    with sqlite3.connect(fresh_db_path) as conn:
+        before_exact = conn.execute(
+            "SELECT COUNT(*) FROM states WHERE state_id = ?",
+            (target_state_id,),
+        ).fetchone()[0]
+        before_value = conn.execute(
+            "SELECT COUNT(*) FROM states WHERE metadata_id = ? AND state = ?",
+            (metadata_id, target_state_value),
+        ).fetchone()[0]
+
+    assert before_exact == 1
+    assert before_value >= 1
+
+    assert fixer.delete_state_by_id(entity_id, target_state_id) is True
+
+    with sqlite3.connect(fresh_db_path) as conn:
+        after_exact = conn.execute(
+            "SELECT COUNT(*) FROM states WHERE state_id = ?",
+            (target_state_id,),
+        ).fetchone()[0]
+        after_value = conn.execute(
+            "SELECT COUNT(*) FROM states WHERE metadata_id = ? AND state = ?",
+            (metadata_id, target_state_value),
+        ).fetchone()[0]
+
+    assert after_exact == 0
+    assert after_value == before_value - 1
+
+    assert fixer.delete_state_by_id(entity_id, target_state_id) is False


### PR DESCRIPTION
## Summary
- show the surrounding rows for a state_id and require explicit confirmation before deleting it
- document the safer delete_id flow and add a repository instruction to always bump the add-on version
- bump the add-on version to 1.3

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d866f064a083328f5994cf4d171b9d