### PR TITLE
Fix debug SSH access

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "Homeassistant Recorder Database Editor"
 description: "Tool for edit and fix entities/sensors values in Homeassistant Recorder Database."
-version: "1.4"
+version: "1.5"
 slug: "ha_recorder_db_editor"
 url: "https://github.com/Duelion/ha-recorder-db-editor"
 init: false

--- a/run.sh
+++ b/run.sh
@@ -42,7 +42,12 @@ if [ "$SSH_ENABLED" = "true" ]; then
         echo "[INFO] SSH debug shell enabled"
         echo "debug:${CONFIGURED_PASSWORD}" | chpasswd
         unset CONFIGURED_PASSWORD DEBUG_PASSWORD
-        /usr/sbin/dropbear -E -w -p "$SSH_PORT" &
+        # The debug user intentionally runs with UID 0 so it can manage
+        # recorder files owned by root.  Dropbear's "-w" flag forbids any
+        # UID 0 password logins, which would also block the debug account.
+        # Avoid that flag so the debug shell remains accessible while the
+        # root account itself stays locked.
+        /usr/sbin/dropbear -E -p "$SSH_PORT" &
     fi
 else
     echo "[INFO] SSH debug shell is disabled"


### PR DESCRIPTION
## Summary
- allow the debug shell user to authenticate again by starting Dropbear without the root-login ban
- document why the `-w` flag cannot be used with the UID 0 debug account
- bump the add-on version to 1.5

## Testing
- bash -n run.sh

------
https://chatgpt.com/codex/tasks/task_b_68d86d95a7088332b5a2808d261c033e