### PR TITLE
Add confirmation preview for sensor delete command

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Enter path to HA database or press ENTER key for confirm default `/config/home-a
 | `sensor find <entity_id>`                | Show `metadata_id` and recent state records. |
 | `sensor values <entity_id>`              | List all unique values stored for the sensor. |
 | `sensor raw <entity_id>`                 | Show 200 recent raw `states` records. |
-| `sensor delete <entity_id> <value>`      | Completely delete value from `states`, `statistics`, and `statistics_short_term`. |
+| `sensor delete <entity_id> <value>`      | Preview affected rows, confirm, then delete value from `states`, `statistics`, and `statistics_short_term`. |
 | `sensor delete_id <entity_id> <state_id>`| Preview nearby rows and confirm before deleting a single `states` entry by `state_id`. |
 
 ---

--- a/cli.py
+++ b/cli.py
@@ -573,18 +573,66 @@ class RecorderCli:
             print(f"Sensor '{entity_id}' not found.")
             return
 
-        summary: DeletionSummary = self._fixer.delete_state_everywhere(entity_id, value)
-        if summary.total == 0:
+        preview = self._fixer.get_state_deletion_preview(entity_id, value)
+        if preview is None or preview.total == 0:
             print(
                 f"No records matched entity '{entity_id}' with state '{value}'."
             )
-        else:
-            print(
-                "Deleted "
-                f"{summary.states} from states, "
-                f"{summary.statistics} from statistics, "
-                f"{summary.statistics_short_term} from statistics_short_term."
+            return
+
+        print(f"Planned deletion summary for '{entity_id}' = '{value}':")
+        print(f"  • states rows: {preview.states_count}")
+
+        if preview.states_count:
+            first_seen = self._format_summary_timestamp(
+                preview.first_seen, preview.first_seen_ts
             )
+            last_seen = self._format_summary_timestamp(
+                preview.last_seen, preview.last_seen_ts
+            )
+            print(f"    first seen: {first_seen}")
+            print(f"    last seen:  {last_seen}")
+
+        print(f"  • statistics rows: {preview.statistics_count}")
+        print(
+            "  • statistics_short_term rows: "
+            f"{preview.statistics_short_term_count}"
+        )
+
+        if preview.examples:
+            print("Sample states to be removed (most recent first):")
+
+            for row in preview.examples:
+                timestamp = self._format_timestamp(row)
+                print(
+                    f"    - {timestamp} → {row['state']}"
+                    f" (id: {row['state_id']})"
+                )
+
+        try:
+            confirmation = self._session.prompt(
+                "Type 'delete' to confirm removal of all matching rows "
+                "(press Enter to cancel): ",
+                completer=None,
+            )
+        except (KeyboardInterrupt, EOFError):
+            print("\nDeletion cancelled.")
+            return
+
+        if confirmation.strip().lower() != "delete":
+            print("Deletion cancelled.")
+            return
+
+        summary: DeletionSummary = self._fixer.delete_state_everywhere(
+            entity_id, value
+        )
+
+        print(
+            "Deleted "
+            f"{summary.states} from states, "
+            f"{summary.statistics} from statistics, "
+            f"{summary.statistics_short_term} from statistics_short_term."
+        )
 
         self._refresh_entity_ids()
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "Homeassistant Recorder Database Editor"
 description: "Tool for edit and fix entities/sensors values in Homeassistant Recorder Database."
-version: "1.5"
+version: "1.6"
 slug: "ha_recorder_db_editor"
 url: "https://github.com/Duelion/ha-recorder-db-editor"
 init: false

--- a/fixer.py
+++ b/fixer.py
@@ -26,6 +26,30 @@ class DeletionSummary:
 
 
 @dataclass(frozen=True)
+class StateDeletionPreview:
+    """Summary of rows that would be removed by deleting a state value."""
+
+    states_count: int = 0
+    statistics_count: int = 0
+    statistics_short_term_count: int = 0
+    first_seen_ts: float | None = None
+    last_seen_ts: float | None = None
+    first_seen: str | None = None
+    last_seen: str | None = None
+    examples: tuple[sqlite3.Row, ...] = ()
+
+    @property
+    def total(self) -> int:
+        """Return the total number of rows that would be removed."""
+
+        return (
+            self.states_count
+            + self.statistics_count
+            + self.statistics_short_term_count
+        )
+
+
+@dataclass(frozen=True)
 class ValueStatistics:
     """Aggregated information for a sensor state value."""
 
@@ -166,6 +190,98 @@ class RecorderFixer:
         except sqlite3.DatabaseError:
             self.conn.rollback()
             raise
+
+    def get_state_deletion_preview(
+        self, entity_id: str, state_value: str, *, sample_limit: int = 5
+    ) -> StateDeletionPreview | None:
+        """Return a summary of rows that would be deleted for ``state_value``."""
+
+        metadata_id = self.get_metadata_id(entity_id)
+        if metadata_id is None:
+            return None
+
+        summary_cursor = self.conn.execute(
+            """
+            SELECT
+                COUNT(*) AS count,
+                MIN(last_updated_ts) AS first_seen_ts,
+                MAX(last_updated_ts) AS last_seen_ts,
+                MIN(last_updated) AS first_seen,
+                MAX(last_updated) AS last_seen
+            FROM states
+            WHERE metadata_id = ? AND state = ?
+            """,
+            (metadata_id, state_value),
+        )
+        summary_row = summary_cursor.fetchone()
+
+        states_count = int(summary_row["count"]) if summary_row and summary_row["count"] else 0
+        first_seen_ts = (
+            float(summary_row["first_seen_ts"])
+            if summary_row and summary_row["first_seen_ts"] is not None
+            else None
+        )
+        last_seen_ts = (
+            float(summary_row["last_seen_ts"])
+            if summary_row and summary_row["last_seen_ts"] is not None
+            else None
+        )
+        first_seen = summary_row["first_seen"] if summary_row else None
+        last_seen = summary_row["last_seen"] if summary_row else None
+
+        sample_cursor = self.conn.execute(
+            """
+            SELECT state_id, state, last_updated, last_updated_ts
+            FROM states
+            WHERE metadata_id = ? AND state = ?
+            ORDER BY COALESCE(last_updated_ts, 0) DESC
+            LIMIT ?
+            """,
+            (metadata_id, state_value, sample_limit),
+        )
+        examples = tuple(sample_cursor.fetchall())
+
+        statistics_metadata_id = self.get_statistic_id(entity_id)
+        numeric_value = self._coerce_state_to_float(state_value)
+
+        statistics_count = 0
+        statistics_short_term_count = 0
+
+        if statistics_metadata_id is not None and numeric_value is not None:
+            for table_name in ("statistics", "statistics_short_term"):
+                cursor = self.conn.execute(
+                    f"""
+                    SELECT COUNT(*) AS count
+                    FROM {table_name}
+                    WHERE metadata_id = ? AND (
+                        state = ? OR min = ? OR max = ? OR mean = ?
+                    )
+                    """,
+                    (
+                        statistics_metadata_id,
+                        numeric_value,
+                        numeric_value,
+                        numeric_value,
+                        numeric_value,
+                    ),
+                )
+                count = cursor.fetchone()["count"]
+
+                if table_name == "statistics":
+                    statistics_count = int(count)
+                else:
+                    statistics_short_term_count = int(count)
+
+        return StateDeletionPreview(
+            states_count=states_count,
+            statistics_count=statistics_count,
+            statistics_short_term_count=statistics_short_term_count,
+            first_seen_ts=first_seen_ts,
+            last_seen_ts=last_seen_ts,
+            first_seen=first_seen,
+            last_seen=last_seen,
+            examples=examples,
+        )
 
     def delete_state_by_id(self, entity_id: str, state_id: int) -> bool:
         """Delete a single ``states`` row identified by ``state_id``."""

--- a/tests/test_fixer.py
+++ b/tests/test_fixer.py
@@ -137,6 +137,35 @@ def test_get_state_context_returns_neighbors(fixer):
     assert all(row["state_id"] > state_id for row in after_rows)
 
 
+def test_get_state_deletion_preview_returns_sample_rows(fixer):
+    preview = fixer.get_state_deletion_preview(
+        "binary_sensor.fritzbox_pia_verbindung",
+        "on",
+        sample_limit=3,
+    )
+
+    assert preview is not None
+    assert preview.states_count > 0
+    assert 0 < len(preview.examples) <= 3
+    assert preview.total >= preview.states_count
+
+
+def test_get_state_deletion_preview_includes_statistics_counts(fixer):
+    preview = fixer.get_state_deletion_preview(
+        "sensor.heizung_wohnzimmer_batterie",
+        "72.0",
+        sample_limit=2,
+    )
+
+    assert preview is not None
+    assert preview.states_count > 0
+    assert len(preview.examples) <= 2
+    assert (
+        preview.statistics_count > 0
+        or preview.statistics_short_term_count > 0
+    )
+
+
 def test_delete_state_everywhere_removes_matching_states(fixer, fresh_db_path):
     entity_id = "binary_sensor.fritzbox_pia_verbindung"
     state_value = "on"


### PR DESCRIPTION
## Summary
- add a deletion preview helper that summarizes matching states and statistics rows
- require confirmation for `sensor delete` after showing affected rows and sample data
- document the new workflow and bump the add-on config version

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d8719bf7e883329ccf7cb1d07d4a60